### PR TITLE
feat: Add promote tag to release archive in S3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@ name: CI
 
 on:
   push:
+    branches:
+      - '**'
 
 jobs:
   lint:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,6 +24,8 @@ jobs:
       - name: Upload to s3
         run: >
           aws s3api copy-object
+          --tagging-directive REPLACE
+          --tagging promote=YES
           --copy-source ${{ secrets.RSP_NONPROD_S3_BUCKET_NAME }}/${{ env.COPY_SOURCE }}
           --key ${{ env.KEY_PATH }}/release-${{ github.ref_name }}.zip
           --bucket ${{ secrets.RSP_NONPROD_S3_BUCKET_NAME }}


### PR DESCRIPTION
## Description

- Add promote tag to the release archive in the release workflow
- Update CI workflow to only run on pushes to branches so tags won't trigger the CI run

Related issue: [RSP-2120](https://dvsa.atlassian.net/browse/RSP-2120)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
