### PR TITLE
fix: Add handling for Capita unrecoverable failures

### DIFF
--- a/src/functions/checkForOrphanedPayments.js
+++ b/src/functions/checkForOrphanedPayments.js
@@ -70,6 +70,14 @@ async function handlePenNotExist(message) {
 			logInfo(StatusCode.CancelledPayment, cancelMessage);
 			return cancelMessage;
 		}
+
+		// If the payment failed, exit and delete the message from the queue
+		if (code === 810) {
+			const cancelMessage = `Payment with receipt reference ${message.ReceiptReference} failed. CPMS returned code ${code}. Removing from SQS queue.`;
+			logInfo(StatusCode.CpmsCodeReceived, cancelMessage);
+			return cancelMessage;
+		}
+
 		// If payment is confirmed by CPMS, create a record in the payments table
 		if (code === 801) {
 			return handlePaymentConfirmed(message, auth_code);


### PR DESCRIPTION
## Description

- If Capita is down and returns an 810 - Gateway Error, this means the payment has failed and cannot be recovered
- This is a final status and will not change
- Add check for this code and return successfully so the item is removed from the queue and doesn't retry
- Ticket 

Related issue: [RSP-2235](https://dvsa.atlassian.net/browse/RSP-2235)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [x] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
